### PR TITLE
Fix PDF text extraction bug

### DIFF
--- a/search_index.py
+++ b/search_index.py
@@ -56,7 +56,9 @@ def extract_text_from_file(filepath):
             try:
                 reader = pypdf.PdfReader(filepath)
                 for page in reader.pages:
-                    text += page.extract_text() + "\n"
+                    page_text = page.extract_text()
+                    if page_text:
+                        text += page_text + "\n"
             except pypdf.errors.PdfReadError as pdf_err:
                  print(f"Warning: Could not read PDF {filepath}: {pdf_err}")
                  return None # Skip broken PDFs


### PR DESCRIPTION
## Summary
- avoid failing when `extract_text()` returns `None`

## Testing
- `python search_index.py --help` *(fails: ModuleNotFoundError: No module named 'sentence_transformers')*

------
https://chatgpt.com/codex/tasks/task_e_68473921c5308327bf0b026ed85c371b